### PR TITLE
refactor + using a .ini config + add unittest

### DIFF
--- a/ctSESAM.py
+++ b/ctSESAM.py
@@ -1,29 +1,98 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
+import os
 from hashlib import pbkdf2_hmac
+import random
+import string
+import configparser
 
-small_letters = list('abcdefghijklmnopqrstuvwxyz')
-big_letters = list('ABCDEFGHJKLMNPQRTUVWXYZ')
-numbers = list('0123456789')
-special_characters = list('#!"§$%&/()[]{}=-_+*<>;:.')
-password_characters = small_letters + big_letters + numbers + special_characters
-salt = "pepper"
+
+DEFAULT_CONFIG='~/ctSESAM.ini'
+SPECIAL_CHARACTERS = '#!"§$%&/()[]{}=-_+*<>;:.'
+PASSWORD_CHARACTERS = string.ascii_letters + string.digits + SPECIAL_CHARACTERS
+
+
+class SesamConfig(object):
+    def __init__(self, filepath=None, verbose=True):
+        self.filepath = os.path.expanduser(filepath or DEFAULT_CONFIG)
+        self.verbose = verbose
+
+    def create_and_read(self):
+        """
+        Load config from a existing .ini file.
+        Create a default .ini, if not exist.
+        """
+        if not os.path.isfile(self.filepath):
+            self.write_defaults()
+        self.load_from_config()
+
+    def write_defaults(self):
+        """
+        Create .ini file with defaults and a new, random 'salt' value.
+        """
+        config = configparser.ConfigParser()
+        config['pbkdf2'] = {"hash_name": "sha512", "iterations": 4096}
+        config['user_settings'] = {
+            "salt": ''.join(random.choice(string.ascii_letters + string.digits) for i in range(10)),
+            "default_length": 10,
+        }
+        with open(self.filepath, "w") as f:
+            f.write("# config file for c't SESAM\n")
+            f.write("# Please make a backup!\n")
+            config.write(f)
+        if self.verbose:
+            print("\nConfig file created here:")
+            print(self.filepath)
+            print("Please make a backup!\n")
+
+    def load_from_config(self):
+        """
+        Load config from a .ini file.
+        The file and all config entries must exist.
+        """
+        config = configparser.ConfigParser()
+        read_ok = config.read(self.filepath, encoding="utf-8")
+        if self.filepath not in read_ok:
+            raise RuntimeError("Error reading config file: %s" % self.filepath)
+
+        try:
+            self.hash_name = config['pbkdf2']['hash_name']
+            self.iterations = config.getint('pbkdf2', 'iterations')
+            self.salt = config['user_settings']['salt']
+            self.default_length = config.getint('user_settings', 'default_length')
+        except KeyError as err:
+            raise RuntimeError("Can't parse config file '%s' KeyError: %s" % (self.filepath, err))
 
 
 def convert_bytes_to_password(hashed_bytes, length):
-    number = int.from_bytes(hashed_bytes, byteorder='big')
+    numbers = int.from_bytes(hashed_bytes, byteorder='big')
     password = ''
-    while number > 0 and len(password) < length:
-        password = password + password_characters[number % len(password_characters)]
-        number = number // len(password_characters)
+    while numbers > 0 and len(password) < length:
+        password = password + PASSWORD_CHARACTERS[numbers % len(PASSWORD_CHARACTERS)]
+        numbers = numbers // len(PASSWORD_CHARACTERS)
     return password
 
-master_password = input('Masterpasswort: ')
-domain = input('Domain: ')
-while len(domain) < 1:
-    print('Bitte gib eine Domain an, für die das Passwort generiert werden soll.')
-    domain = input('Domain: ')
-hash_string = domain + master_password
-hashed_bytes = pbkdf2_hmac('sha512', hash_string.encode('utf-8'), salt.encode('utf-8'), 4096)
-print('Passwort: ' + convert_bytes_to_password(hashed_bytes, 10))
+
+def generate_password(domain, master_password, cfg):
+    hash_string = bytes(domain + master_password, "utf-8")
+    salt = bytes(cfg.salt, "utf-8")
+    hashed_bytes = pbkdf2_hmac(cfg.hash_name, hash_string, salt, cfg.iterations)
+    return convert_bytes_to_password(hashed_bytes, cfg.default_length)
+
+
+def cli(cfg):
+    master_password = input('Masterpasswort: ')
+    domain = ""
+    while not domain:
+        print('Bitte gib eine Domain an, für die das Passwort generiert werden soll.')
+        domain = input('Domain: ')
+
+    password = generate_password(domain, master_password, cfg)
+    print('Passwort: %s' % password)
+
+
+if __name__ == "__main__":
+    cfg = SesamConfig()
+    cfg.create_and_read()
+    cli(cfg)

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,23 @@
+
+import tempfile
+import unittest
+import ctSESAM
+
+
+class TestCtSESAM(unittest.TestCase):
+    def setUp(self):
+        self.test_config = tempfile.NamedTemporaryFile(prefix='ctSESAM_tests_', suffix=".ini")
+        self.cfg = ctSESAM.SesamConfig(self.test_config.name, verbose=False)
+        self.cfg.write_defaults()
+        self.cfg.load_from_config()
+        self.cfg.salt="pepper"
+
+    def tearDown(self):
+        self.test_config.close()
+
+    def test_salt(self):
+        self.assertEqual(self.cfg.salt, "pepper")
+
+    def test_generate_password(self):
+        password = ctSESAM.generate_password(domain="foobar.tld", master_password="12345678", cfg=self.cfg)
+        self.assertEqual(password, "Kcr_1-=2fQ")


### PR DESCRIPTION
Maybe that is out of project scope ;)

I think it's nice if "salt" and some other options are stored independent from the script.
So i add "SesamConfig", that will create a "~/ctSESAM.ini" with a random 'salt' on first run. If the .ini file exist, it used the salt from there...

I add a small unittests, too.

EDIT: Maybe https://github.com/pinae/ctSESAM-python-memorizing is a better place for this?!?
